### PR TITLE
refactor: RestClient json conversion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter'
+	implementation(platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:7.6.0'))
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
+++ b/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
@@ -1,0 +1,27 @@
+package com.example.listings.datafetchers;
+import com.netflix.graphql.dgs.DgsComponent;
+import com.netflix.graphql.dgs.DgsQuery;
+import com.example.listings.models.ListingModel;
+import java.util.List;
+
+@DgsComponent
+public class ListingDataFetcher {
+    @DgsQuery
+    public List<ListingModel> featuredListings() {
+        ListingModel meteorListing = new ListingModel();
+        meteorListing.setId("1");
+        meteorListing.setTitle("Beach house on the edge of the Laertes meteor");
+        meteorListing.setCostPerNight(360.00);
+        meteorListing.setClosedForBookings(false);
+        meteorListing.setNumOfBeds(3);
+
+        ListingModel gasGiantListing = new ListingModel();
+        gasGiantListing.setId("2");
+        gasGiantListing.setTitle("Unforgettable atmosphere, unbeatable heat, tasteful furnishings");
+        gasGiantListing.setCostPerNight(124.00);
+        gasGiantListing.setClosedForBookings(true);
+        gasGiantListing.setNumOfBeds(4);
+
+        return List.of(meteorListing, gasGiantListing);
+    }
+}

--- a/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
+++ b/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.example.listings.datasources.ListingService;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.io.IOException;
+import com.netflix.graphql.dgs.InputArgument;
 
 @DgsComponent
 public class ListingDataFetcher {
@@ -19,5 +20,10 @@ public class ListingDataFetcher {
     @DgsQuery
     public List<ListingModel> featuredListings() throws IOException {
         return listingService.featuredListingsRequest();
+    }
+
+    @DgsQuery
+    public ListingModel listing(@InputArgument String id) {
+        return listingService.listingRequest(id);
     }
 }

--- a/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
+++ b/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
@@ -3,25 +3,21 @@ import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsQuery;
 import com.example.listings.models.ListingModel;
 import java.util.List;
+import com.example.listings.datasources.ListingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.io.IOException;
 
 @DgsComponent
 public class ListingDataFetcher {
+
+    private final ListingService listingService;
+
+    @Autowired
+    public ListingDataFetcher(ListingService listingService) {
+        this.listingService = listingService;
+    }
     @DgsQuery
-    public List<ListingModel> featuredListings() {
-        ListingModel meteorListing = new ListingModel();
-        meteorListing.setId("1");
-        meteorListing.setTitle("Beach house on the edge of the Laertes meteor");
-        meteorListing.setCostPerNight(360.00);
-        meteorListing.setClosedForBookings(false);
-        meteorListing.setNumOfBeds(3);
-
-        ListingModel gasGiantListing = new ListingModel();
-        gasGiantListing.setId("2");
-        gasGiantListing.setTitle("Unforgettable atmosphere, unbeatable heat, tasteful furnishings");
-        gasGiantListing.setCostPerNight(124.00);
-        gasGiantListing.setClosedForBookings(true);
-        gasGiantListing.setNumOfBeds(4);
-
-        return List.of(meteorListing, gasGiantListing);
+    public List<ListingModel> featuredListings() throws IOException {
+        return listingService.featuredListingsRequest();
     }
 }

--- a/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
+++ b/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
@@ -13,6 +13,9 @@ import com.netflix.graphql.dgs.DgsData;
 import com.example.listings.generated.types.Amenity;
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment;
 import graphql.execution.DataFetcherResult;
+import com.netflix.graphql.dgs.DgsMutation;
+import com.example.listings.generated.types.CreateListingInput;
+import com.example.listings.generated.types.CreateListingResponse;
 
 @DgsComponent
 public class ListingDataFetcher {
@@ -50,5 +53,24 @@ public class ListingDataFetcher {
             return listing.getAmenities();
         }
         return listingService.amenitiesRequest(id);
+    }
+
+    @DgsMutation
+    public CreateListingResponse createListing(@InputArgument CreateListingInput input) {
+        CreateListingResponse response = new CreateListingResponse();
+        try {
+            ListingModel createdListing = listingService.createListingRequest(input);
+            response.setListing(createdListing);
+            response.setCode(200);
+            response.setMessage("success");
+            response.setSuccess(true);
+        } catch (Exception e) {
+            response.setListing(null);
+            response.setCode(500);
+            response.setMessage(e.getMessage());
+            response.setSuccess(false);
+        }
+
+        return response;
     }
 }

--- a/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
+++ b/src/main/java/com/example/listings/datafetchers/ListingDataFetcher.java
@@ -1,11 +1,10 @@
 package com.example.listings.datafetchers;
+
 import com.netflix.graphql.dgs.DgsComponent;
 import com.netflix.graphql.dgs.DgsQuery;
 import com.example.listings.models.ListingModel;
 import java.util.List;
 import com.example.listings.datasources.ListingService;
-import org.springframework.beans.factory.annotation.Autowired;
-import java.io.IOException;
 import java.util.Map;
 
 import com.netflix.graphql.dgs.InputArgument;
@@ -22,12 +21,12 @@ public class ListingDataFetcher {
 
     private final ListingService listingService;
 
-    @Autowired
     public ListingDataFetcher(ListingService listingService) {
         this.listingService = listingService;
     }
+
     @DgsQuery
-    public DataFetcherResult<List<ListingModel>> featuredListings() throws IOException {
+    public DataFetcherResult<List<ListingModel>> featuredListings() {
         List<ListingModel> listings = listingService.featuredListingsRequest();
         return DataFetcherResult.<List<ListingModel>>newResult()
                 .data(listings)
@@ -45,7 +44,7 @@ public class ListingDataFetcher {
     }
 
     @DgsData(parentType="Listing")
-    public List<Amenity> amenities(DgsDataFetchingEnvironment dfe) throws IOException {
+    public List<Amenity> amenities(DgsDataFetchingEnvironment dfe) {
         ListingModel listing = dfe.getSource();
         String id = listing.getId();
         Map<String, Boolean> localContext = dfe.getLocalContext();

--- a/src/main/java/com/example/listings/datasources/ListingService.java
+++ b/src/main/java/com/example/listings/datasources/ListingService.java
@@ -1,0 +1,31 @@
+package com.example.listings.datasources;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.listings.models.ListingModel;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.io.IOException;
+
+@Component
+public class ListingService {
+    private static final String LISTING_API_URL = "https://rt-airlock-services-listing.herokuapp.com";
+    private final RestClient client = RestClient.builder().baseUrl(LISTING_API_URL).build();
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    public List<ListingModel> featuredListingsRequest() throws IOException {
+        JsonNode response = client
+                .get()
+                .uri("/featured-listings")
+                .retrieve()
+                .body(JsonNode.class);
+
+        if (response != null) {
+            return mapper.readValue(response.traverse(), new TypeReference<List<ListingModel>>() {});
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/listings/datasources/ListingService.java
+++ b/src/main/java/com/example/listings/datasources/ListingService.java
@@ -28,4 +28,12 @@ public class ListingService {
 
         return null;
     }
+
+    public ListingModel listingRequest(String id) {
+        return client
+                .get()
+                .uri("/listings/{listing_id}", id)
+                .retrieve()
+                .body(ListingModel.class);
+    }
 }

--- a/src/main/java/com/example/listings/datasources/ListingService.java
+++ b/src/main/java/com/example/listings/datasources/ListingService.java
@@ -9,6 +9,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.io.IOException;
 import com.example.listings.generated.types.Amenity;
+import com.example.listings.generated.types.CreateListingInput;
+import com.example.listings.models.CreateListingModel;
+import org.springframework.http.converter.json.MappingJacksonValue;
 
 
 @Component
@@ -52,5 +55,15 @@ public class ListingService {
         }
 
         return null;
+    }
+
+    public ListingModel createListingRequest(CreateListingInput listing) {
+        MappingJacksonValue serializedListing = new MappingJacksonValue(new CreateListingModel(listing));
+        return client
+                .post()
+                .uri("/listings")
+                .body(serializedListing)
+                .retrieve()
+                .body(ListingModel.class);
     }
 }

--- a/src/main/java/com/example/listings/datasources/ListingService.java
+++ b/src/main/java/com/example/listings/datasources/ListingService.java
@@ -8,6 +8,8 @@ import com.example.listings.models.ListingModel;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.io.IOException;
+import com.example.listings.generated.types.Amenity;
+
 
 @Component
 public class ListingService {
@@ -35,5 +37,20 @@ public class ListingService {
                 .uri("/listings/{listing_id}", id)
                 .retrieve()
                 .body(ListingModel.class);
+    }
+
+    public List<Amenity> amenitiesRequest(String listingId) throws IOException {
+        JsonNode response = client
+                .get()
+                .uri("/listings/{listing_id}/amenities", listingId)
+                .retrieve()
+                .body(JsonNode.class);
+
+        if (response != null) {
+            return mapper.readValue(response.traverse(), new TypeReference<List<Amenity>>() {
+            });
+        }
+
+        return null;
     }
 }

--- a/src/main/java/com/example/listings/datasources/ListingService.java
+++ b/src/main/java/com/example/listings/datasources/ListingService.java
@@ -1,37 +1,27 @@
 package com.example.listings.datasources;
 
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.example.listings.models.ListingModel;
-import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
-import java.io.IOException;
 import com.example.listings.generated.types.Amenity;
 import com.example.listings.generated.types.CreateListingInput;
 import com.example.listings.models.CreateListingModel;
-import org.springframework.http.converter.json.MappingJacksonValue;
-
 
 @Component
 public class ListingService {
-    private static final String LISTING_API_URL = "https://rt-airlock-services-listing.herokuapp.com";
-    private final RestClient client = RestClient.builder().baseUrl(LISTING_API_URL).build();
 
-    private final ObjectMapper mapper = new ObjectMapper();
-    public List<ListingModel> featuredListingsRequest() throws IOException {
-        JsonNode response = client
+    private static final String LISTING_API_URL = "https://rt-airlock-services-listing.herokuapp.com";
+
+    private final RestClient client = RestClient.create(LISTING_API_URL);
+
+    public List<ListingModel> featuredListingsRequest() {
+        return client
                 .get()
                 .uri("/featured-listings")
                 .retrieve()
-                .body(JsonNode.class);
-
-        if (response != null) {
-            return mapper.readValue(response.traverse(), new TypeReference<List<ListingModel>>() {});
-        }
-
-        return null;
+                .body(new ParameterizedTypeReference<List<ListingModel>>() {});
     }
 
     public ListingModel listingRequest(String id) {
@@ -42,27 +32,19 @@ public class ListingService {
                 .body(ListingModel.class);
     }
 
-    public List<Amenity> amenitiesRequest(String listingId) throws IOException {
-        JsonNode response = client
+    public List<Amenity> amenitiesRequest(String listingId) {
+        return client
                 .get()
                 .uri("/listings/{listing_id}/amenities", listingId)
                 .retrieve()
-                .body(JsonNode.class);
-
-        if (response != null) {
-            return mapper.readValue(response.traverse(), new TypeReference<List<Amenity>>() {
-            });
-        }
-
-        return null;
+                .body(new ParameterizedTypeReference<List<Amenity>>() {});
     }
 
     public ListingModel createListingRequest(CreateListingInput listing) {
-        MappingJacksonValue serializedListing = new MappingJacksonValue(new CreateListingModel(listing));
         return client
                 .post()
                 .uri("/listings")
-                .body(serializedListing)
+                .body(new CreateListingModel(listing))
                 .retrieve()
                 .body(ListingModel.class);
     }

--- a/src/main/java/com/example/listings/models/CreateListingModel.java
+++ b/src/main/java/com/example/listings/models/CreateListingModel.java
@@ -1,0 +1,4 @@
+package com.example.listings.models;
+import com.example.listings.generated.types.CreateListingInput;
+
+public record CreateListingModel(CreateListingInput listing) { }

--- a/src/main/java/com/example/listings/models/ListingModel.java
+++ b/src/main/java/com/example/listings/models/ListingModel.java
@@ -1,0 +1,6 @@
+package com.example.listings.models;
+
+import com.example.listings.generated.types.Listing;
+
+public class ListingModel extends Listing {
+}

--- a/src/main/java/com/example/listings/models/ListingModel.java
+++ b/src/main/java/com/example/listings/models/ListingModel.java
@@ -1,6 +1,8 @@
 package com.example.listings.models;
 
 import com.example.listings.generated.types.Listing;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ListingModel extends Listing {
 }

--- a/src/main/java/com/example/listings/models/ListingModel.java
+++ b/src/main/java/com/example/listings/models/ListingModel.java
@@ -1,8 +1,6 @@
 package com.example.listings.models;
 
 import com.example.listings.generated.types.Listing;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
 public class ListingModel extends Listing {
 }

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -1,6 +1,8 @@
 type Query {
     "A curated array of listings to feature on the homepage"
     featuredListings: [Listing!]!
+    "Returns the details about this listing"
+    listing(id: ID!): Listing
 }
 
 "A particular intergalactic location available for booking"
@@ -8,6 +10,8 @@ type Listing {
     id: ID!
     "The listing's title"
     title: String!
+    "The listing's description"
+    description: String!
     "The number of beds available"
     numOfBeds: Int
     "The cost per night"

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -18,4 +18,14 @@ type Listing {
     costPerNight: Float
     "Indicates whether listing is closed for bookings (on hiatus)"
     closedForBookings: Boolean
+    "The amenities available for this listing"
+    amenities: [Amenity!]!
+}
+
+type Amenity {
+    id: ID!
+    "The amenity category the amenity belongs to"
+    category: String!
+    "The amenity's name"
+    name: String!
 }

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -1,0 +1,17 @@
+type Query {
+    "A curated array of listings to feature on the homepage"
+    featuredListings: [Listing!]!
+}
+
+"A particular intergalactic location available for booking"
+type Listing {
+    id: ID!
+    "The listing's title"
+    title: String!
+    "The number of beds available"
+    numOfBeds: Int
+    "The cost per night"
+    costPerNight: Float
+    "Indicates whether listing is closed for bookings (on hiatus)"
+    closedForBookings: Boolean
+}

--- a/src/main/resources/schema/schema.graphqls
+++ b/src/main/resources/schema/schema.graphqls
@@ -29,3 +29,34 @@ type Amenity {
     "The amenity's name"
     name: String!
 }
+
+type Mutation {
+    "Creates a new listing"
+    createListing(input: CreateListingInput!): CreateListingResponse!
+}
+
+input CreateListingInput {
+    "The listing's title"
+    title: String!
+    "The listing's description"
+    description: String!
+    "The number of beds available"
+    numOfBeds: Int!
+    "The cost per night"
+    costPerNight: Float!
+    "Indicates whether listing is closed for bookings (on hiatus)"
+    closedForBookings: Boolean
+    "The Listing's amenities"
+    amenities: [ID!]!
+}
+
+type CreateListingResponse {
+    "Similar to HTTP status code, represents the status of the mutation"
+    code: Int!
+    "Indicates whether the mutation was successful"
+    success: Boolean!
+    "Human-readable message for the UI"
+    message: String!
+    "The newly created listing"
+    listing: Listing
+}


### PR DESCRIPTION
This PR simplifies final solution by leveraging `RestClient` default message converters on json serialization.

Please note that spring boot [advises](https://docs.spring.io/spring-boot/docs/3.2.5/reference/html/io.html#io.rest-client.restclient) to inject pre-configured `RestClient.Builder` (as I suggested [here](https://github.com/apollographql-education/content-feedback/discussions/156#discussioncomment-10237004)) however client is created using `RestClient.create()`. It does make sense for simplicity but I don't have strong position about this. 🙂 

Thank you again for great tutorials! 🚀